### PR TITLE
Update nvm-telescope-fzf build command

### DIFF
--- a/lua/plugins/example.lua
+++ b/lua/plugins/example.lua
@@ -76,7 +76,7 @@ return {
     "telescope.nvim",
     dependencies = {
       "nvim-telescope/telescope-fzf-native.nvim",
-      build = "make",
+      build = "cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release && cmake --install build --prefix build",
       config = function()
         require("telescope").load_extension("fzf")
       end,


### PR DESCRIPTION
Update the build command for nvm-telescope-fzf to match upstream docs and configs documented in https://github.com/nvim-telescope/telescope-fzf-native.nvim#installation docs